### PR TITLE
feat: add mode and collection tabs

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,7 +55,19 @@
   const $partsGrid=document.getElementById('partsGrid');
   const $gearBox=document.querySelector('.gear-box');
   const $techBox=document.getElementById('techBox');
+  const $modeBox=document.getElementById('modeBox');
+  const $collectionBox=document.getElementById('collectionBox');
   const $navItems=document.querySelectorAll('.nav-item');
+  const $modeRadios=document.querySelectorAll('input[name="mode"]');
+  const $medalField=document.getElementById('medalField');
+  const $medalInput=document.getElementById('medalInput');
+  const $set1=document.getElementById('set1');
+  const $set2=document.getElementById('set2');
+  const $set3=document.getElementById('set3');
+  const $set1Value=document.getElementById('set1Value');
+  const $set2Value=document.getElementById('set2Value');
+  const $set3Value=document.getElementById('set3Value');
+  const $collectionGrid=document.querySelector('.collection-grid');
 
   $navItems.forEach(btn=>{
     btn.addEventListener('click',()=>{
@@ -64,14 +76,55 @@
       const tab=btn.dataset.tab;
       const showGear=tab==='all'||tab==='gear';
       const showParts=tab==='all'||tab==='parts';
+      const showMode=tab==='all'||tab==='mode';
+      const showCollection=tab==='all'||tab==='collection';
       if($gearBox) $gearBox.style.display=showGear?'':'none';
       if($logBox) $logBox.style.display=showGear?'':'none';
       if($techBox) $techBox.style.display=showParts?'':'none';
+      if($modeBox) $modeBox.style.display=showMode?'':'none';
+      if($collectionBox) $collectionBox.style.display=showCollection?'':'none';
     });
   });
 
   const $activeNav=document.querySelector('.nav-item.active');
   if($activeNav) $activeNav.click();
+  function updateModeField(){
+    const sel=document.querySelector('input[name="mode"]:checked');
+    if($medalField) $medalField.style.display=(sel&&sel.value==='expedition')?'':'none';
+  }
+  $modeRadios.forEach(r=>{ r.addEventListener('change', updateModeField); });
+  updateModeField();
+  if($medalInput){
+    $medalInput.addEventListener('input',()=>{
+      let v=parseInt($medalInput.value,10);
+      if(!Number.isFinite(v)) v=0;
+      v=Math.max(0,Math.min(45000,v));
+      $medalInput.value=v;
+    });
+  }
+
+  [$set1,$set2,$set3].forEach((slider,idx)=>{
+    if(!slider) return;
+    const spans=[$set1Value,$set2Value,$set3Value];
+    const span=spans[idx];
+    const sync=()=>{ if(span) span.textContent=slider.value; };
+    slider.addEventListener('input',sync);
+    sync();
+  });
+
+  if($collectionGrid){
+    const redImages = Array.from({length:28},(_,i)=>`Image/red${i+1}.png`);
+    const yellowImages = Array.from({length:32},(_,i)=>`Image/yellow${i+1}.png`);
+    const makeItem=(cls,src)=>{
+      const btn=document.createElement('button');
+      btn.type='button';
+      btn.className=`collection-item ${cls}`;
+      btn.style.backgroundImage=`url(${src})`;
+      $collectionGrid.appendChild(btn);
+    };
+    redImages.forEach(src=>makeItem('red',src));
+    yellowImages.forEach(src=>makeItem('yellow',src));
+  }
   if($calcBtn){ $calcBtn.onclick=()=>{ openModal() } }
   if($optCancel){ $optCancel.onclick=()=> closeModal() }
   if($modal){ const $bd=$modal.querySelector('.backdrop'); if($bd){ $bd.onclick=()=> closeModal() } }

--- a/index.html
+++ b/index.html
@@ -10,8 +10,10 @@
   <div class="container layout">
     <nav class="side-nav">
       <button class="nav-item active" data-tab="all">전부보기</button>
+      <button class="nav-item" data-tab="mode">모드</button>
       <button class="nav-item" data-tab="gear">장비</button>
       <button class="nav-item" data-tab="parts">부품</button>
+      <button class="nav-item" data-tab="collection">컬렉션</button>
     </nav>
     <div class="content">
       <!-- 결과 -->
@@ -20,8 +22,20 @@
         <div class="spec-grid" id="specGrid"></div>
       </div>
 
+      <!-- 모드 -->
+      <div class="mode-box" id="modeBox">
+        <div class="mode-options">
+          <label><input type="radio" name="mode" value="normal" checked /> 일반</label>
+          <label><input type="radio" name="mode" value="expedition" /> 달광산원정</label>
+        </div>
+        <div class="field" id="medalField" style="display:none">
+          <label for="medalInput" style="min-width:120px">상대 메달 수</label>
+          <input id="medalInput" type="number" min="0" max="45000" step="1" />
+        </div>
+      </div>
+
       <!-- 장비 -->
-      <div class="gear-box">
+      <div class="gear-box" id="gearBox">
         <div class="gear-head">
           <div class="gear-left">
             <div>CORE : <span id="coreTotal">0개</span></div>
@@ -49,6 +63,28 @@
           <span class="pill">Parts</span>
           <div class="tech-grid" id="partsGrid"></div>
         </div>
+      </div>
+
+      <!-- 컬렉션 -->
+      <div class="collection-box" id="collectionBox">
+        <div class="set-controls">
+          <div class="field">
+            <label for="set1">Set 1</label>
+            <input id="set1" type="range" min="0" max="4" value="0" />
+            <span id="set1Value" class="range-value">0</span>
+          </div>
+          <div class="field">
+            <label for="set2">Set 2</label>
+            <input id="set2" type="range" min="0" max="8" value="0" />
+            <span id="set2Value" class="range-value">0</span>
+          </div>
+          <div class="field">
+            <label for="set3">Set 3</label>
+            <input id="set3" type="range" min="0" max="8" value="0" />
+            <span id="set3Value" class="range-value">0</span>
+          </div>
+        </div>
+        <div class="collection-grid"></div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,11 @@
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,system-ui,"Noto Sans KR",sans-serif}
 .container{max-width:1200px;margin:0 auto;padding:20px}
+.layout{display:flex;gap:20px}
+.side-nav{display:flex;flex-direction:column;gap:10px;width:120px}
+.nav-item{background:linear-gradient(180deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:10px;padding:8px 12px;color:var(--muted);cursor:pointer;text-align:left}
+.nav-item.active{color:var(--accent);border-color:var(--accent)}
+.content{flex:1}
 
 /* 결과 상자 */
 .score-box{background:linear-gradient(180deg,var(--panel),var(--panel-2));padding:18px;border-radius:14px;border:1px solid var(--border);margin-bottom:18px}
@@ -9,6 +14,13 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 .spec-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:10px}
 .spec{background:rgba(255,255,255,.05);border:1px solid var(--border);border-radius:10px;padding:8px 12px;font-size:14px}
 .spec strong{color:var(--accent)}
+
+/* 모드 상자 */
+.mode-box{background:linear-gradient(180deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:16px;padding:16px;margin-bottom:24px}
+.mode-options{display:flex;gap:20px}
+.mode-options label{display:flex;align-items:center;gap:6px;cursor:pointer}
+.mode-box .field{display:flex;gap:8px;align-items:center;margin-top:12px}
+.mode-box input[type=number]{width:160px;padding:6px 8px;border-radius:8px;border:1px solid var(--border);background:rgba(255,255,255,.05);color:var(--text)}
 
 /* 장비 상자 */
 .gear-box{background:linear-gradient(180deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:16px;padding:12px 16px;margin-bottom:24px}
@@ -75,3 +87,18 @@ svg#lineChart{width:100%;height:160px;display:block}
 .cost{margin-top:6px;color:#57e087;font-weight:800;display:flex;gap:6px;align-items:center;justify-content:center}
 .check{position:absolute;right:-6px;top:-6px;width:26px;height:26px;border-radius:50%;background:#0ea5ff;display:grid;place-items:center;border:3px solid #0b1632}
 .oct.wrap{position:relative}
+
+/* 컬렉션 */
+.collection-box{background:linear-gradient(180deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:16px;padding:16px;margin:24px 0}
+.set-controls{display:flex;gap:20px;margin-bottom:16px}
+.set-controls .field{display:flex;align-items:center;gap:8px;flex:1}
+.set-controls label{min-width:50px}
+.set-controls input[type=range]{flex:1;-webkit-appearance:none;height:4px;border-radius:4px;background:var(--border);outline:none}
+.set-controls input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:14px;height:14px;border-radius:50%;background:var(--accent);cursor:pointer}
+.set-controls input[type=range]::-moz-range-track{height:4px;border-radius:4px;background:var(--border)}
+.set-controls input[type=range]::-moz-range-thumb{width:14px;height:14px;border-radius:50%;background:var(--accent);border:none;cursor:pointer}
+.range-value{width:28px;text-align:right;font-weight:800}
+.collection-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(60px,1fr));gap:10px}
+.collection-item{width:60px;height:60px;border-radius:12px;border:1px solid var(--border);background-size:cover;background-position:center;background-repeat:no-repeat;padding:0;cursor:pointer}
+.collection-item.red{background-color:#ff556e}
+.collection-item.yellow{background-color:#ffe56e}


### PR DESCRIPTION
## Summary
- show current values next to collection sliders and apply custom slider styling
- dynamically populate collection with 28 red and 32 yellow items, each using unique image paths
- generate collection items in script and clean up markup
- render collection entries as image buttons for future interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b4575f15648320ac8d31444cbe4858